### PR TITLE
Ungroup(): cleanWeirData, naming:cnt_groups

### DIFF
--- a/R/clean_WeirData.R
+++ b/R/clean_WeirData.R
@@ -61,7 +61,8 @@ clean_weirData <- function(data){
                 slice(which.max(trapped_date)) %>%
                 select(tmp_fish_id, final_location = current_location), by = 'tmp_fish_id') %>%
     select(trap_year, trapped_date, tmp_fish_id, current_location, final_location, everything()) %>%
-    select(-tmp_id, -pit, -op)
+    select(-tmp_id, -pit, -op) %>%
+    ungroup()
 
   return(trap_df)
 

--- a/R/cnt_groups.R
+++ b/R/cnt_groups.R
@@ -11,7 +11,14 @@ cnt_groups <- function(.data, .summary_var, ...){
   # quote count variable
   summary_var <- enquo(.summary_var)
 
+  n_name <- paste('n_', quo_name(summary_var), sep='')
+
   dat <- .data %>%
     group_by(...) %>%
     count(!!summary_var)
+
+  colnum <- ncol(dat)
+  colnames(dat)[colnum] <- n_name
+
+  return(dat)
 }


### PR DESCRIPTION
should be good to go.  Renaming the column was much more difficult than it should have been.  Your fault.