### PR TITLE
shuffled order of 'scope' checks. The NPT cannot be first because if …

### DIFF
--- a/R/get_FINSdata.R
+++ b/R/get_FINSdata.R
@@ -26,12 +26,13 @@ get_FINSdata <- function(module = c('Trapping', 'Release', 'Spawning'),
   module <- match.arg(module)
   scope <- match.arg(scope)
 
-  if(scope == 'NPT'){
-    scope = NULL
-    }
 
   if(scope == 'FINS Domain'){
     scope = 'domain'
+  }
+
+  if(scope == 'NPT'){
+    scope = NULL
   }
 
   # assign user agent to the GitHub repo for this package


### PR DESCRIPTION
…it sets scope to NULL, the next argument doesn't understand how to evaluate that.